### PR TITLE
Auto-find HTML files

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ if (args.serve) {
   const express = require('express')
   const http = require('http')
   const app = express()
-  app.use(express.static('./docs'))
+  app.use(express.static('./docs', { extensions: ['html'] }))
   app.use(function (req, res) {
     try {
       fs.readFile('./docs/404.html', function (error, content) {


### PR DESCRIPTION
Our prod server, render.com, also does this, so we should allow it in development for consistency

i.e. `https://hackathon.treasurehacks.org/previous/v3` automatically shows `.../v3.html`, so we should allow that on `localhost` as well (currently, this path must end in `v3.html` to find the file)